### PR TITLE
Fix Alpine compiler install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine
 
 # Evitá errores por falta de compiladores
-RUN apt-get update && apt-get install -y gcc build-essential
+RUN apk add --no-cache gcc musl-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- replace `apt-get` install for compilers with `apk` in the Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`